### PR TITLE
Fix contribution link on https://docs.kyve.network/

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ KYVE is developed open-source and publicly. You can find our GitHub here: [https
 
 If you want to integrate your own KYVE architecture, check out `@kyve/core`.
 
-{% page-ref page="logic/overview.md" %}
+https://github.com/KYVENetwork/core#readme

--- a/README.md
+++ b/README.md
@@ -19,6 +19,4 @@ KYVE is developed open-source and publicly. You can find our GitHub here: [https
 
 ## Contributing
 
-If you want to integrate your own KYVE architecture, check out `@kyve/core`.
-
-https://github.com/KYVENetwork/core#readme
+If you want to integrate your own KYVE architecture, check out [`@kyve/core`](https://github.com/KYVENetwork/core#readme).


### PR DESCRIPTION
Contribution link on https://docs.kyve.network/ is broken
Not sure my fix is the correct link but at least it comes at your attention 