### PR TITLE
Tweaks to Data Pipeline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 
-### Installation
+## Installation
 
-```
-$ yarn
+```sh
+yarn
 ```
 
 ### Local Development
 
-```
-$ yarn start
+```sh
+yarn start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
 ### Build
 
-```
-$ yarn build
+```sh
+yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -28,14 +28,14 @@ This command generates static content into the `build` directory and can be serv
 
 Using SSH:
 
-```
-$ USE_SSH=true yarn deploy
+```sh
+USE_SSH=true yarn deploy
 ```
 
 Not using SSH:
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
+```sh
+GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/docs/data_engineers/accessing_data/elt_pipeline/airbyte_local_deployment.md
+++ b/docs/data_engineers/accessing_data/elt_pipeline/airbyte_local_deployment.md
@@ -4,19 +4,20 @@ sidebar_position: 1
 
 # Airbyte Local Deployment
 
-In this step, we'll deploy Airbyte locally on your machine. Make sure you have installed Docker and Docker Compose on
-your system as shown in the [Overview section](overview.md).
+In this step, we'll deploy Airbyte locally on your machine. Make sure you have installed Docker and Docker Compose on your system as shown in the [Overview section](overview.md).
 
 To deploy Airbyte locally, run the following commands in your terminal:
 
 ```sh
 git clone https://github.com/KYVENetwork/airbyte.git
 ```
+
 ```sh
 cd airbyte
 ```
+
 ```sh
-docker-compose up
+docker compose up
 ```
 
 After the deployment is complete, you'll be able to access the Airbyte UI at <http://localhost:8000/>.
@@ -27,7 +28,6 @@ BASIC_AUTH_USERNAME=airbyte
 BASIC_AUTH_PASSWORD=password
 ```
 
-When you first access the Website, you will be directed to the onboarding screen. You can submit your email address to receive Airbyte notifications.
-Enter your email address and proceed if you wish.
+When you first access the Website, you will be directed to the onboarding screen. Enter an email to proceed.
 
-<img  src="/img/elt/airbyte_preferences.png" width="500px;" />
+<img src="/img/elt/airbyte_preferences.png" alt="Airbyte Preferences" width="500px;" />

--- a/docs/data_engineers/accessing_data/elt_pipeline/elt_destinations/snowflake.md
+++ b/docs/data_engineers/accessing_data/elt_pipeline/elt_destinations/snowflake.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 # Snowflake Destination
 
 This page will guide you through setting up an ELT pipeline using Snowflake to fetch data from
-a [KYVE data pool](https://docs.kyve.network/basics/pools.html) and import it into a Snowflake data warehouse.
+a [KYVE data pool](/introduction/architecture.md) and import it into a Snowflake data warehouse.
 
 ## About Snowflake
 
@@ -13,9 +13,6 @@ The KYVE Data Pipeline enables easy import of KYVE data into any data warehouse 
 supported by [Airbyte](https://airbyte.com/). With the [ELT](https://en.wikipedia.org/wiki/Extract,_load,_transform)
 format, data analysts and engineers can now confidently source KYVE data without worrying about its validity or
 reliability.
-
-This tutorial will guide you through setting up an ELT pipeline to fetch data from
-a [KYVE data pool](https://docs.kyve.network/basics/pools.html) and import it into the Snowflake data warehouse.
 
 A data warehouse is a centralized repository of data that is optimized for querying and analysis. It is designed for
 [analytical processing (OLAP)](https://en.wikipedia.org/wiki/Online_analytical_processing). A data warehouse can handle
@@ -80,7 +77,7 @@ To create a user you can either create it on the UI or using SQL:
 - Using SQL:
 
     - To run
-      this [command](https://docs.snowflake.com/en/sql-reference/sql/create-user.html#:~:text=Objects%20%26%20Columns.-,Access%20Control%20Requirements,-A%20role%20used),
+      this [command](https://docs.snowflake.com/en/sql-reference/sql/create-user),
       the current user must have a `USERADMIN` role or one with higher privileges (run this command in the worksheet):
 
       > NOTE: An owner with `ACCOUNTADMIN` privileges will work as well since it has higher level of access

--- a/docs/data_engineers/accessing_data/elt_pipeline/kyve_source.md
+++ b/docs/data_engineers/accessing_data/elt_pipeline/kyve_source.md
@@ -5,13 +5,13 @@ sidebar_position: 2
 
 In this step, you will configure the `KYVE` source for your Airbyte deployment.
 
-1. Change to the `source-kyve` directory:
+1. In a new Terminal window change to the `source-kyve` directory:
 
    ```sh
    cd airbyte-integrations/connectors/source-kyve
    ```
 
-2. Build the docker image for the Kyve source:
+2. Build the Docker image for the KYVE source:
 
    ```sh
    docker build . -t airbyte/source-kyve:dev
@@ -19,16 +19,16 @@ In this step, you will configure the `KYVE` source for your Airbyte deployment.
 
 3. In the Airbyte UI, navigate to the settings page and add a new source connector.
 
-   <img src="/img/elt/airbyte_new_connector.jpg"/>
+   <img src="/img/elt/airbyte_new_connector.jpg" alt="Airbyte Settings" />
 
-4. You should fill the following fields as show in the figure bellow:
+4. Fill out the fields as follows, then click Add:
 
-   - **Connector display name**: `Kyve` (here you can put whatever you want)
+   - **Connector display name**: `KYVE` (or any other name)
    - **Docker repository name**: `airbyte/source-kyve`
    - **Docker image tag**: `dev`
-   - **Connector Documentation URL**: `https://docs.kyve.network/` 
-   
+   - **Connector documentation URL**: `https://docs.kyve.network/`
 
-   <img src="/img/elt/airbyte_new_connector2.jpg"/>
+   <br></br>
+   <img src="/img/elt/airbyte_new_connector2.jpg" alt="Airbyte Add New Connector" />
 
-Congratulations! You are now ready to create a pipeline with KYVE as a source.
+Congratulations! You are now ready to set up KYVE as a source and create a data pipeline.

--- a/docs/data_engineers/accessing_data/elt_pipeline/kyve_source.md
+++ b/docs/data_engineers/accessing_data/elt_pipeline/kyve_source.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 In this step, you will configure the `KYVE` source for your Airbyte deployment.
 
-1. In a new Terminal window change to the `source-kyve` directory:
+1. In a new terminal window change to the `source-kyve` directory:
 
    ```sh
    cd airbyte-integrations/connectors/source-kyve

--- a/docs/data_engineers/accessing_data/elt_pipeline/overview.md
+++ b/docs/data_engineers/accessing_data/elt_pipeline/overview.md
@@ -9,12 +9,13 @@ supported by [Airbyte](https://airbyte.com/). With the [ELT](https://en.wikipedi
 format, data analysts and engineers can now confidently source KYVE data without worrying about its validity or
 reliability.
 
-The sections that follow were created to help you build up a local testbed for testing KYVE's DataPipeline.
+The sections that follow were created to help you set up a local environment for testing KYVE's Data Pipeline.
 
-### System Requirements
-To experiment with the ELT pipeline via [Airbyte](https://airbyte.com/), you must ensure that your PC has been configured correctly.
+## System Requirements
 
-#### Windows
+To experiment with the ELT pipeline via [Airbyte](https://airbyte.com/) let's first ensure your computer is configured correctly.
+
+### Windows
 
 For Windows users, the Windows Subsystem for Linux 2 (WSL2) must be installed. You must be running Windows 10 version
 2004 or higher (build 19041 or higher), or Windows 11 to use the commands in this tutorial.
@@ -38,7 +39,7 @@ For Windows users, the Windows Subsystem for Linux 2 (WSL2) must be installed. Y
 3. To ensure that WSL2 has been installed successfully, run the following command:
 
    ```bat
-    wsl -l -v
+   wsl -l -v
    ```
 
    Expected output:
@@ -51,20 +52,17 @@ For Windows users, the Windows Subsystem for Linux 2 (WSL2) must be installed. Y
 4. After you've set up WSL2 successfully, install `Docker desktop on Windows` by following the
    steps [here](https://docs.docker.com/desktop/install/windows-install/).
 
-#### Mac
+### Mac
 
-We will be utilizing `brew` in order to install Docker Desktop and `docker-compose` on Mac. In order to install `brew`
-please follow the instructions listed [here](https://brew.sh/).
+1. Make sure you have Homebrew installed. If not you can follow the instructions listed [here](https://brew.sh/).
 
-1. You are now ready to install Docker Desktop and `docker-compose`. Run the following command on your terminal:
+1. Make sure you have Docker Desktop installed. If not you can install it with Homebrew in your Terminal:
 
    ```sh
-   brew install docker docker-compose
+   brew install --cask docker
    ```
 
-#### Linux
+### Linux
 
 1. In order to install Docker and `docker-compose` on Linux, please follow the instructions
-   listed [here](https://docs.docker.com/engine/install/) and choose your Linux distribution. Remember to also run the
-   Post-installation steps listed [here](https://docs.docker.com/engine/install/linux-postinstall/).
-
+   listed [here](https://docs.docker.com/engine/install/) and choose your Linux distribution. Remember to also run the post-installation steps listed [here](https://docs.docker.com/engine/install/linux-postinstall/).

--- a/docs/data_engineers/accessing_data/elt_pipeline/overview.md
+++ b/docs/data_engineers/accessing_data/elt_pipeline/overview.md
@@ -56,7 +56,7 @@ For Windows users, the Windows Subsystem for Linux 2 (WSL2) must be installed. Y
 
 1. Make sure you have Homebrew installed. If not you can follow the instructions listed [here](https://brew.sh/).
 
-1. Make sure you have Docker Desktop installed. If not you can install it with Homebrew in your Terminal:
+2. Make sure you have Docker Desktop installed. If not you can install it with Homebrew in your terminal:
 
    ```sh
    brew install --cask docker


### PR DESCRIPTION
Minor tweaks I made as I went through the tutorial (which was super smooth!)

In addition to small language/clarification edits, also:

- Latest Docker, at least on Mac, uses [Compose V2](https://docs.docker.com/compose/compose-v2/) so `brew` installing `docker-compose` isn't required
- My editor also runs `markdownlint` on the files I touched which resulted in some minor formatting changes