### PR TITLE
fix: :memo: Correct Bundlr cli usage instructions

### DIFF
--- a/docs/validators/protocol_nodes/pools/cosmos_hub/requirements.md
+++ b/docs/validators/protocol_nodes/pools/cosmos_hub/requirements.md
@@ -84,7 +84,7 @@ which holds some funds:
 
 ```bash
 $ bundlr fund 1000000000000 -h https://node1.bundlr.network -w arweave.json -c arweave
-
+> Loaded address: 7smNXWVNbTinRPuKbrke0XR0N9N6FgTBVCh20niXEbU
 > ? Confirmation: send 1000000000000 Winston to dev.bundlr.network (35jqt51H71Tf4YmZfoGvN9FLw62a4aPnLgZa9KLdwLo)?
 > Y / N y
 > Funding receipt:
@@ -93,10 +93,10 @@ $ bundlr fund 1000000000000 -h https://node1.bundlr.network -w arweave.json -c a
 ```
 
 In this example we funded Bundlr with 1 $AR which should be more than enough. After about ~30 minutes
-you can view your balance with:
+you can view your balance using your arweave address (which will show up under `Loaded address` like the example seen above) with: 
 
 ```bash
-$ bundlr balance 35jqt51H71Tf4YmZfoGvN9FLw62a4aPnLgZa9KLdwLo -h https://node1.bundlr.network -c arweave
+$ bundlr balance <your arweave address> -h https://node1.bundlr.network -c arweave
 
 > Balance: 1000000000000 Winston (1AR)
 ```

--- a/docs/validators/protocol_nodes/pools/cosmos_hub/requirements.md
+++ b/docs/validators/protocol_nodes/pools/cosmos_hub/requirements.md
@@ -85,10 +85,10 @@ which holds some funds:
 ```bash
 $ bundlr fund 1000000000000 -h https://node1.bundlr.network -w arweave.json -c arweave
 > Loaded address: 7smNXWVNbTinRPuKbrke0XR0N9N6FgTBVCh20niXEbU
-> ? Confirmation: send 1000000000000 Winston to dev.bundlr.network (35jqt51H71Tf4YmZfoGvN9FLw62a4aPnLgZa9KLdwLo)?
+> ? Confirmation: send 1000000000000 Winston to node1.bundlr.network (OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs)?
 > Y / N y
 > Funding receipt:
-> Amount: 1000000000000 with Fee: 1379016 to 35jqt51H71Tf4YmZfoGvN9FLw62a4aPnLgZa9KLdwLo
+> Amount: 1000000000000 with Fee: 1379016 to OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs
 > ID: 7cI6jpfpx6A2z8F5AoVHvZn9Az_BWPgvKzBCoE5w07A
 ```
 
@@ -106,7 +106,7 @@ In order to withdraw your funds from Bundlr simply execute:
 ```bash
 $ bundlr withdraw 500000000000 -h https://node1.bundlr.network -w arweave.json -c arweave
 
-> ? Confirmation: withdraw 500000000000 winston from node1.bundlr.network (35jqt51H71Tf4YmZfoGvN9FLw62a4aPnLgZa9KLdwLo)?
+> ? Confirmation: withdraw 500000000000 winston from node1.bundlr.network (OXcT1sVRSA5eGwt2k6Yuz8-3e3g9WJi5uSE99CWqsBs)?
 > Y / N y
 > Withdrawal request for 500000000000 winston successful
 > Transaction ID: xcmxJmHyNS502fzqiT66rNeIOSldKGDWR8XsL9auDfs with network fee 1379016 for a total cost of 2858032


### PR DESCRIPTION
Corrects documentation covering the usage of the `bundlr balance`  command to reduce confusion over which address should be supplied, as well as updating other command output to be consistent with what a user would see.