### PR TITLE
fix: celestia documentation

### DIFF
--- a/pools.js
+++ b/pools.js
@@ -266,9 +266,9 @@ const Celestia = {
   configToml: {
     description:
       "Due to the size of the block_results response and because Celestia disables the storage of block results by default, ",
-    code: 'abci_discard_abci_responses = false\ntimeout_broadcast_tx_commit = "120s"',
+    code: 'discard_abci_responses = false\ntimeout_broadcast_tx_commit = "120s"',
   },
-  appToml: 'pruning = "everything"\nindex-events = [""]',
+  appToml: 'pruning = "everything"\nindex-events = [""]\n\n[state-sync]\n\nsnapshot-interval = 0\nsnapshot-keep-recent = 0',
 };
 
 const CelestiaSSync = {


### PR DESCRIPTION
Pull request includes the following changes:

-  Set `snapshot-interval` and `snapshot-keep-recent` settings to 0 in the [state-sync] section of the app.toml file to fix an error occurring when configuring `pruning = "everything"`. 

`"Error: cannot enable state sync snapshots with 'everything' pruning setting: error in app.toml" `

- Corrected a typo in the `discard_abci_responses` setting according to the [official documentation](https://docs.celestia.org/nodes/full-consensus-node#optional-discard-abci-responses-configuration).

